### PR TITLE
Install by Default if yast2-s390 is Installed

### DIFF
--- a/package/yast2-reipl.changes
+++ b/package/yast2-reipl.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Mar 30 14:20:27 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Install by default if yast2-s390 is installed (bsc#1158036)
+- 4.2.2
+
+-------------------------------------------------------------------
 Thu Aug 22 16:11:21 CEST 2019 - schubi@suse.de
 
 - Using rb_default_ruby_abi tag in the spec file in order to

--- a/package/yast2-reipl.spec
+++ b/package/yast2-reipl.spec
@@ -39,6 +39,8 @@ Requires:       yast2 >= 2.21.22
 # needed for chreipl and lsreipl commands
 Requires:       s390-tools
 
+Supplements:    yast2-s390
+
 ExclusiveArch:  s390 s390x
 
 %description

--- a/package/yast2-reipl.spec
+++ b/package/yast2-reipl.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-reipl
-Version:        4.2.1
+Version:        4.2.2
 Release:        0
 Summary:        YaST2 - IPL loader
 License:        GPL-2.0-only


### PR DESCRIPTION
## Trello

https://trello.com/c/ODOyd5Yh/


## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1158036

## Problem

This module is not installed by default in an S/390 installation, but it should be.

## Solution

Added a `Supplements: yast2-s390` to the .spec file so this module is also installed whenever the yast2-s390 module is installed (which is the default for S/390 installations because it's there in the base system pattern).

## Test

We agreed to leave testing to our S/390 experts.

## Related PR

https://github.com/yast/yast-cio/pull/35